### PR TITLE
修复 enable_predict_space: true 时移动光标后空格无法上屏候选的 bug

### DIFF
--- a/lua/wanxiang/user_predict.lua
+++ b/lua/wanxiang/user_predict.lua
@@ -707,10 +707,24 @@ function P.func(key, env)
         if CONFIG.ENABLE_PREDICT_SPACE then
             -- enable_predict_space: true
             if key.keycode == 0x20 then
-                ctx:clear()
-                reset_memory_chain(env, "空格打断联想并上屏")
-                env.engine:commit_text(" ")
-                return 1
+                -- ============== 修改：仅当输入完全是预测占位符时才拦截空格 ==============
+                local current_input = ctx.input or ""
+                local is_predict_placeholder = (current_input ~= "") and s_find(current_input, "^" .. PH_CHAR .. "+$")
+
+                if is_predicting and is_predict_placeholder then
+                    -- 原有逻辑：预测状态下，空格上屏空格
+                    ctx:clear()
+                    reset_memory_chain(env, "空格打断联想并上屏")
+                    env.engine:commit_text(" ")
+                    return 1
+                else
+                    -- ============== 新增：否则重置状态，放行空格 ==============
+                    is_predicting = false
+                    predict_count = 0
+                    pending_cands = nil
+                    return 2 -- 放行空格，让原生处理
+                end
+                -- ==========修改结束=======
             elseif is_alt_key then
                 ctx:clear()
                 reset_memory_chain(env, "替身键打断联想")

--- a/lua/wanxiang/user_predict.lua
+++ b/lua/wanxiang/user_predict.lua
@@ -707,24 +707,20 @@ function P.func(key, env)
         if CONFIG.ENABLE_PREDICT_SPACE then
             -- enable_predict_space: true
             if key.keycode == 0x20 then
-                -- ============== 修改：仅当输入完全是预测占位符时才拦截空格 ==============
                 local current_input = ctx.input or ""
                 local is_predict_placeholder = (current_input ~= "") and s_find(current_input, "^" .. PH_CHAR .. "+$")
 
                 if is_predicting and is_predict_placeholder then
-                    -- 原有逻辑：预测状态下，空格上屏空格
                     ctx:clear()
                     reset_memory_chain(env, "空格打断联想并上屏")
                     env.engine:commit_text(" ")
                     return 1
                 else
-                    -- ============== 新增：否则重置状态，放行空格 ==============
                     is_predicting = false
                     predict_count = 0
                     pending_cands = nil
                     return 2 -- 放行空格，让原生处理
                 end
-                -- ==========修改结束=======
             elseif is_alt_key then
                 ctx:clear()
                 reset_memory_chain(env, "替身键打断联想")


### PR DESCRIPTION
代码修改内容与描述均为豆包免费版专家模型生成，已在我的PC端小狼毫与移动端fcitx5测试通过，还请开发者老大看看修改是否正确。

当开启预测功能且 enable_predict_space 配置为 true 时（# true: 按空格上屏空格; false:空格提交候选。一般手机开电脑关，空格当上屏则，Tab、Alt按键当作空格），存在一个跨平台可复现的 bug：
输入一个词触发预测候选（输入框显示 › 占位符），
此时发现前方已输入内容要增加文字，需要移动光标过去输入内容，手动移动光标（PC 鼠标点击，移动端触屏点击），
输入新的内容，
按下空格键，不会上屏当前新输入的候选词，而是直接上屏一个空格。
当 enable_predict_space=false 时，相同操作流程可以正常上屏候选词。（感觉像是移动光标这个操作没有重置之前的预测候选，新输入内容也没有重置之前的预测候选，导致按下空格想上屏新输入内容变成了“enable_predict_space 配置为 true 时（# true: 按空格上屏空格”）

复现步骤
启用万象拼音预测功能：patch: switches/@8/reset: 1
在 wanxiang.custom.yaml 中添加配置："user_predict/enable_predict_space": true
重新部署输入法
输入 "你好"，触发预测候选（输入框显示 ›，以及预测候选列表）
点击移动光标到前方其他位置
输入其他任意内容
按下空格键
预期行为：上屏新输入的候选内容。
实际行为：直接上屏一个空格

修复方案
仅修改 ENABLE_PREDICT_SPACE=true 分支下的空格键处理逻辑，不改动其他任何代码：
增加输入内容检测：判断当前输入是否完全由预测占位符 › 组成
只有当同时满足"处于预测状态" 和 "输入是预测占位符" 两个条件时，才执行 "空格打断联想并上屏空格" 的原有逻辑
其他情况（如移动光标后输入了新的拼音）：重置预测状态，放行空格键让 Rime 原生逻辑处理上屏候选

修改前：

https://github.com/user-attachments/assets/8c672f38-7ac7-49ea-8482-e4acf5b493c1


https://github.com/user-attachments/assets/08223e7d-e115-490a-9531-66b42ce84143


修改后：

https://github.com/user-attachments/assets/abce0d6a-6b4d-4c91-8c9f-9e380d0eefde


https://github.com/user-attachments/assets/a20a7d97-9d23-43cd-94f6-954c554c491d



