### PR TITLE
修复预测空格开关失效的问题并调整预测过程中回车键的行为

### DIFF
--- a/lua/wanxiang/user_predict.lua
+++ b/lua/wanxiang/user_predict.lua
@@ -757,8 +757,8 @@ function P.func(key, env)
         
         if repr == "Return" then
             ctx:clear()
-            reset_memory_chain(env, "打断键清除预测") 
-            return 1
+            reset_memory_chain(env, "回车键打断预测并输入回车") 
+            return 2
         end
     end
 

--- a/lua/wanxiang/user_predict.lua
+++ b/lua/wanxiang/user_predict.lua
@@ -738,9 +738,6 @@ function P.func(key, env)
                     env.engine:commit_text(" ")
                     return 1
                 else
-                    is_predicting = false
-                    predict_count = 0
-                    pending_cands = nil
                     return 2 -- 放行空格，让原生处理
                 end
             elseif is_alt_key then


### PR DESCRIPTION
很抱歉上次的pr把预测的功能搞炸了。。。
现在已经修好了

回车键在预测过程中之前是按回车打断预测然后什么都不做，
修改为按回车打断预测并直接上屏一个回车。